### PR TITLE
For nested values use the correct encrypted flag

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -219,7 +219,7 @@ function walkAndDecrypt(
         caad,
         digest,
         false,
-        false,
+        unencrypted_branch,
         encryptionModifier,
       );
     }


### PR DESCRIPTION
This should fix https://github.com/koblas/sops-decoder-node/issues/10